### PR TITLE
\Magento\Backend\Model\View\Result\RedirectFactory already exists in …

### DIFF
--- a/app/code/Magestore/Bannerslider/Controller/Adminhtml/AbstractAction.php
+++ b/app/code/Magestore/Bannerslider/Controller/Adminhtml/AbstractAction.php
@@ -61,11 +61,6 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
     protected $_resultPageFactory;
 
     /**
-     * @var \Magento\Backend\Model\View\Result\RedirectFactory
-     */
-    protected $_resultRedirectFactory;
-
-    /**
      * Banner factory.
      *
      * @var \Magestore\Bannerslider\Model\BannerFactory
@@ -104,7 +99,6 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
      * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
      * @param \Magento\Framework\View\Result\LayoutFactory $resultLayoutFactory
      * @param \Magento\Backend\Model\View\Result\ForwardFactory $resultForwardFactory
-     * @param \Magento\Backend\Model\View\Result\RedirectFactory $resultRedirectFactory
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Backend\Helper\Js $jsHelper
      */
@@ -119,7 +113,6 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
         \Magento\Framework\View\Result\PageFactory $resultPageFactory,
         \Magento\Framework\View\Result\LayoutFactory $resultLayoutFactory,
         \Magento\Backend\Model\View\Result\ForwardFactory $resultForwardFactory,
-        \Magento\Backend\Model\View\Result\RedirectFactory $resultRedirectFactory,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Backend\Helper\Js $jsHelper
     ) {
@@ -132,7 +125,6 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
         $this->_resultPageFactory = $resultPageFactory;
         $this->_resultLayoutFactory = $resultLayoutFactory;
         $this->_resultForwardFactory = $resultForwardFactory;
-        $this->_resultRedirectFactory = $resultRedirectFactory;
 
         $this->_bannerFactory = $bannerFactory;
         $this->_sliderFactory = $sliderFactory;

--- a/app/code/Magestore/Bannerslider/Controller/Adminhtml/AbstractAction.php
+++ b/app/code/Magestore/Bannerslider/Controller/Adminhtml/AbstractAction.php
@@ -131,4 +131,33 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
         $this->_bannerCollectionFactory = $bannerCollectionFactory;
         $this->_sliderCollectionFactory = $sliderCollectionFactory;
     }
+
+    /**
+     * get back result redirect after add/edit.
+     *
+     * @param \Magento\Backend\Model\View\Result\Redirect $resultRedirect
+     *
+     * @return \Magento\Backend\Model\View\Result\Redirect
+     */
+    protected function _getBackResultRedirect(\Magento\Backend\Model\View\Result\Redirect $resultRedirect, $paramCrudId = null)
+    {
+        switch ($this->getRequest()->getParam('back')) {
+            case 'edit':
+                $resultRedirect->setPath(
+                    '*/*/edit',
+                    [
+                        static::PARAM_CRUD_ID => $paramCrudId,
+                        '_current' => true,
+                    ]
+                );
+                break;
+            case 'new':
+                $resultRedirect->setPath('*/*/new');
+                break;
+            default:
+                $resultRedirect->setPath('*/*/');
+        }
+
+        return $resultRedirect;
+    }
 }

--- a/app/code/Magestore/Bannerslider/Controller/Adminhtml/Slider/Delete.php
+++ b/app/code/Magestore/Bannerslider/Controller/Adminhtml/Slider/Delete.php
@@ -43,7 +43,7 @@ class Delete extends \Magestore\Bannerslider\Controller\Adminhtml\Slider
         } catch (\Exception $e) {
             $this->messageManager->addError($e->getMessage());
         }
-        $resultRedirect = $this->_resultRedirectFactory->create();
+        $resultRedirect = $this->resultRedirectFactory->create();
 
         return $resultRedirect->setPath('*/*/');
     }

--- a/app/code/Magestore/Bannerslider/Controller/Adminhtml/Slider/Save.php
+++ b/app/code/Magestore/Bannerslider/Controller/Adminhtml/Slider/Save.php
@@ -38,7 +38,7 @@ class Save extends \Magestore\Bannerslider\Controller\Adminhtml\Slider
      */
     public function execute()
     {
-        $resultRedirect = $this->_resultRedirectFactory->create();
+        $resultRedirect = $this->resultRedirectFactory->create();
         $formPostValues = $this->getRequest()->getPostValue();
 
         if (isset($formPostValues['slider'])) {


### PR DESCRIPTION
## Problem
Bannerslider does not work in production mode. Navigating in Magento admin gives this error message:
```
Fatal error: Call to a member function addLink() on a non-object in /private/var/www/m2/vendor/magento/module-backend/App/AbstractAction.php on line 153
```

## How to recreate
1. `php bin/magento deploy:mode:set production`
2. Navigate to Admin » Banner Slider » Manage Sliders (or any menu item)

## Expected result
It should be possible access the grid section, and to save/edit/delete banners/sliders.
