### PR TITLE
Make images work with database storage

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -21,11 +21,18 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
-	<default>
-	    <bannerslider>
-	        <general>
-	            <enable_frontend>1</enable_frontend>
-	        </general>
-	    </bannerslider>
-	</default>
+    <default>
+        <bannerslider>
+            <general>
+                <enable_frontend>1</enable_frontend>
+            </general>
+        </bannerslider>
+        <system>
+            <media_storage_configuration>
+                <allowed_resources>
+                    <bannerslider_folder>magestore</bannerslider_folder>
+                </allowed_resources>
+            </media_storage_configuration>
+        </system>
+    </default>
 </config>


### PR DESCRIPTION
I was having trouble using this extension in conjunction with the database file storage system. For some reason, the slider images weren't showing up!

Anyway, I investigated and it turns out that the `pub/get.php` file will only download files found in specific subfolders in the `media` folder, e.g. `catalog`, `wysiwyg`. Fortunately, the list of allowed files is configurable. This change adds the `magestore` folder to the list of subfolders that can be downloaded by `pub/get.php`.