### PR TITLE
check if $category is null before invoking method

### DIFF
--- a/Block/Bannerslider.php
+++ b/Block/Bannerslider.php
@@ -158,19 +158,20 @@ class Bannerslider extends \Magento\Framework\View\Element\Template
             ->addFieldToFilter('position', $position)
             ->addFieldToFilter('status', Status::STATUS_ENABLED);
         $category = $this->_coreRegistry->registry('current_category');
-        $categoryPathIds = $category->getPathIds();
-
-        foreach ($sliderCollection as $slider) {
-            $sliderCategoryIds = explode(',', $slider->getCategoryIds());
-            if (count(array_intersect($categoryPathIds, $sliderCategoryIds)) > 0) {
-                $this->append(
-                    $this->getLayout()->createBlock(
-                        'Magestore\Bannerslider\Block\SliderItem'
-                    )->setSliderId($slider->getId())
-                );
+        if (!is_null($category)) {
+            $categoryPathIds = $category->getPathIds();
+    
+            foreach ($sliderCollection as $slider) {
+                $sliderCategoryIds = explode(',', $slider->getCategoryIds());
+                if (count(array_intersect($categoryPathIds, $sliderCategoryIds)) > 0) {
+                    $this->append(
+                        $this->getLayout()->createBlock(
+                            'Magestore\Bannerslider\Block\SliderItem'
+                        )->setSliderId($slider->getId())
+                    );
+                }
             }
         }
-
         return $this;
     }
 


### PR DESCRIPTION
Varnish uses edge side includes (ESI) that will cause this function to be executed without a current category in the ESI request, so please check if the category is null. There is probably a more robust way to handle this, though.