### PR TITLE
Removing parent from first node fixes the issue of the menu item not showing. 

### DIFF
--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -22,7 +22,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
-    	<add id="Magestore_Bannerslider::bannerslider" title="Banner Slider" module="Magestore_Bannerslider" sortOrder="10" resource="Magestore_Bannerslider::bannerslider" parent="Magento_Backend::content"/>
+    	<add id="Magestore_Bannerslider::bannerslider" title="Banner Slider" module="Magestore_Bannerslider" sortOrder="10" resource="Magestore_Bannerslider::bannerslider"/>
 
         <!-- Magestore_Bannerslider::bannerslider_bannerslider -->
 


### PR DESCRIPTION
I replicated the problem two users had in issue #99; installed the module and couldn't see the menu item at all.

I found that removing the parent="Magento_Backend::content" from the first add node in the menu.xml file got it working for me on my 2.2.1. build.

I don't think specifying a parent is necessary at that level because it will default to Magento Backend. For example, no parent is specified in the first add node in the following example:

https://www.magestore.com/magento-2-tutorial/how-to-create-admin-menu-in-magento-2/