### PR TITLE
BUGFIX: fixed issue unknown entity_id column - Mage version 2.3.4

### DIFF
--- a/Block/Adminhtml/Slider/Grid.php
+++ b/Block/Adminhtml/Slider/Grid.php
@@ -189,7 +189,7 @@ class Grid extends \Magento\Backend\Block\Widget\Grid\Extended
      */
     protected function _prepareMassaction()
     {
-        $this->setMassactionIdField('entity_id');
+        $this->setMassactionIdField('slider_id');
         $this->getMassactionBlock()->setFormFieldName('slider');
 
         $this->getMassactionBlock()->addItem(


### PR DESCRIPTION
**Description:**

1. Go to Admin Dashboard

2. Click Manager Sliders

3. The grid will be blank

**Issue:**

> main.CRITICAL: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'main_table.entity_id' in 'field list', query was: SELECT `main_table`.`entity_id` FROM `prefix_magestore_bannerslider_slider` AS `main_table` [] []


**Magento Version:** 
2.3.4